### PR TITLE
Copied content from Gdoc to g-legal-framework

### DIFF
--- a/pages/guidance/g-legal-framework.md
+++ b/pages/guidance/g-legal-framework.md
@@ -1,21 +1,123 @@
 ---
-title: TEXT
-description: coming soon...
-contributors: 
+title: Legal framework for research data
+description: How to create a legal framework for research data
+contributors: [Heleri Inno, Rudolf Vohnout, Hana Marčetić, Aina Jene, Wolmar Nyberg Åkerström, Jana Martínková, Aída Moure Fernández, Mijke Jetten]
 page_id: g-legal-framework
 type: Guidance
 related_pages: [support-communication]
 ---
-
 ## Context
-[Collins dictionary](https://www.collinsdictionary.com/dictionary/english/legal-framework#google_vignette) defines legal framework as “a particular set of rules, ideas, or beliefs which you use in order to deal with problems or to decide what to do”. In the context of data stewardship and research data management, this topic covers all the laws, regulations, and institutional policies that govern how research data is handled throughout the research project. This includes crucial areas like data protection (e.g., GDPR), intellectual property, data sharing protocols, and ethical considerations. Although IT security, data protection (e.g., GDPR) and ethics are their own topics in this handbook, this section will briefly cover these since they all fall under the general legal framework. 
+[Collins dictionary](https://www.collinsdictionary.com/dictionary/english/legal-framework#google_vignette) defines legal framework as “a particular set of rules, ideas, or beliefs which you use in order to deal with problems or to decide what to do”. In the context of data stewardship and research data management, this topic covers the laws, regulations, national and institutional policies that govern how research data is handled throughout the research project. This includes crucial areas like data protection (e.g., GDPR), intellectual property, data sharing protocols and ethical considerations. Although information security, data protection (e.g., GDPR) and ethics are their own topics in this handbook, this section will briefly cover these since they all fall under the general legal framework. 
 
-However, this Data Steward Handbook does not detail all the legislation and policies that may apply, as that will differ across nodes and state lines, but it outlines important considerations and guidelines on how to evaluate the circumstances and potential for improvements by providing examples, tips and tricks, and good practice instances. 
+The Data Steward Handbook does not detail all the legislation and policies that may apply, as these vary across states and institutions. Instead, it highlights important considerations and offers guidelines on how to evaluate the circumstances and identify potential opportunities for improvements by providing examples, tips and tricks, and good practice instances.
 
-A data steward’s tasks do not cover the legal section per se. Most of this work should be covered by the legal department of your organisation. However, a data steward should be knowledgeable about the general knowledge and procedures, so he/she/they can offer support with basic requirements and know when to contact the lawyers. Building strong connections with the legal departments (including Data Protection Officer) where they exist is essential to foster collaboration, knowledge sharing, and professional growth within this field. However, if your organisation is small, it might not have a legal department, which puts an additional strain on the data steward to seek out legal support and develop a level of understanding of the legal context.
+The responsibilities of Data steward do not generally include the legal section per se. Most of this work is usually carried  by the legal department of an organisation. However, a data steward should have a general understanding of relevant legal concepts  and procedures to  support basic requirements and to recognize when to involve legal experts. Build good ties with the legal department and the Data Protection Officer. This helps with teamwork and sharing knowledge. In small organisations without legal support, data stewards may need to seek advice from external experts.
 
 
-## Guidelines
+
+## Guidelines (from google-doc)
+Awareness of these legal obligations, covering data protection, intellectual property and contractual responsibilities safeguards both researchers and institutions. While data stewards are not legal experts they play a key role in recognising potential risks, guiding researchers to appropriate resources and ensuring that procedures are communicated clearly and effectively. The guidelines bellow outline practical steps for embedding legal awareness, consistent processes and collaboration across organisations, focusing on four drivers: clear responsibilities, accessible procedures, contextual guidance and continuous improvement.
+
+**1. Define and communicate responsibilities clearly**
+
+**✔ Clarify the data steward’s role in relation to legal topics**
+
+Data stewards play a supporting role — not as legal experts, but as facilitators who help researchers identify risks and connect them with the appropriate institutional experts. Data stewards bridge the gap between legal experts and researchers, translating between different vocabularies, workflows and expectations. Their role is to describe the legal process to researchers, in collaboration with the legal department, and facilitate a two-way exchange of information. Ensure that these responsibilities are documented within institutional RDM policies and communicated consistently across departments.
+
+* Introduce the data steward role during researcher onboarding or department meetings: explain that you are (in most cases) the *first point of contact* for general RDM-related legal questions.  
+* Publish a one-page overview of what the data steward can help with (e.g. general awareness, referrals, compliance checks).  
+* Map and clearly document responsibilities regarding RDM for researchers, data stewards, ethics committees, Data Protection Officers (DPOs) and legal advisors to ensure clarity and accountability.  
+* Keep contact details readily available and easy to find. Include links to the Legal Department, Data Protection Officer (DPO), and Technology Transfer Officer (TTO) in your presentations, training materials and on RDM pages.  
+* Use recognised frameworks and checklists (e.g., EOSC-Pillar Legal Compliance Guidelines) to demonstrate alignment with established best practices and national regulations.  
+* Ensure that the roles (Data Steward, Data Protection Officers and legal advisors) are reflected in institutional policies, training materials and RDM plan templates.
+
+Relevant links: 
+
+* EOSC-Pillar: Legal Compliance Guidelines for Researchers — Checklist [https://doi.org/10.5281/zenodo.6327668](https://doi.org/10.5281/zenodo.6327668)  
+* EU Commission: GDPR Decision Tree (Ethics / Data Protection) [https://ec.europa.eu/assets/rtd/ethics-data-protection-decision-tree/index.html](https://ec.europa.eu/assets/rtd/ethics-data-protection-decision-tree/index.html) 
+
+**2. Provide accessible and consistent procedures**
+
+**✔ Create visual and easy-to-follow guidance**
+
+Simplify legal decision-making with structured and visual resources to help researchers understand what to do and who to contact.
+
+* Offer visual tools such as GDPR decision maps or institutional flowcharts that outline the steps for managing legal aspects.  
+* Adapt existing resources (e.g. RDM Decision Tree, GDPR decision trees) with your institution’s specific details (such as contacts) and procedures.  
+* Develop short “if/then” guides (e.g, “If you collect personal data → contact the DPO before storing it”).  
+* Ensure all materials are version-controlled and reviewed regularly to keep them consistent with current legislation.  
+* Share anonymised case studies showing how common legal issues have been resolved within your institution.
+
+Relevant links: 
+
+* EOSC-Pillar: Legal Compliance Guidelines for Researchers — Checklist [https://doi.org/10.5281/zenodo.6327668](https://doi.org/10.5281/zenodo.6327668) 
+* EU Commission: GDPR Decision Tree (Ethics / Data Protection) [https://ec.europa.eu/assets/rtd/ethics-data-protection-decision-tree/index.html](https://ec.europa.eu/assets/rtd/ethics-data-protection-decision-tree/index.html)   
+* Research Data Management Decision Tree [https://doi.org/10.5281/zenodo.7190005](https://doi.org/10.5281/zenodo.7190005) 
+
+**✔ Establish collaborative workflows with the legal department**
+
+Develop transparent, predictable systems for managing and tracking legal queries to improve efficiency and build researcher confidence.
+
+* Implement or refine a shared ticketing or request-tracking system for legal queries(e.g., GDPR, contracts, intellectual property).  
+* Ensure requests are routed automatically to the appropriate team (Legal, DPO, TTO) and that researchers can track the status of their requests.  
+* Define expected response times for requests (e.g. legal reviews may take up to 10 working days).  
+* Document these workflows institutionally and make them visible on the institution’s intranet or RDM pages.  
+* Use aggregated ticket data to identify recurring issues, update FAQs and improve future guidance.  
+* Schedule periodic coordination meetings between data stewards and legal representatives to review processes and address systemic bottlenecks.  
+* Use review outcomes to inform the next cycle of updates to policies, templates and training — closing the feedback loop.
+
+**3. Tailor support to data types and disciplines**  
+Familiarise researchers with relevant legal requirements and recommend setting up dedicated task forces or work packages to address legal aspects of data management. Help research teams describe their data flows and system setups to early identify potential compliance gaps.
+
+**✔ Recognise disciplinary differences**  
+Legal requirements vary across research fields. Provide short, targeted “domain-related legal requirements sheets” with typical issues and institutional contacts:
+
+* Health and clinical data: ethics approval, sensitive data handling and data transfer agreements.  
+* Social sciences: consent forms, anonymisation and secondary data use.  
+* Industry collaborations: intellectual property, non-disclosure agreements and licensing terms.
+
+Update these sheets annually or when relevant legislation changes apply.
+
+**✔ Integrate legal checks into research workflows**  
+Embed legal compliance steps directly into existing research processes to ensure early and consistent consideration of legal requirements.
+
+* Add compliance-related questions and checklists into ethics reviews, grant application templates and data management plan (DMP) tools.  
+* Highlight repository-specific rules (open, restricted, embargoed) and acceptable data-sharing conditions.  
+* Ensure DMP templates and ethics forms include references to relevant institutional legal guidance or templates.
+
+**4. Build and maintain legal awareness through training and communication**  
+Establish continuous communication channels between data stewards and legal support (including the DPO) to ensure alignment in RDM processes and consistent interpretation of requirements.
+
+**✔ Deliver targeted legal awareness trainings**  
+Integrate legal aspects into broader RDM training to make them part of everyday research practice.
+
+* Integrate legal aspects into RDM training rather than treating them as a separate topic.  
+* Offer short, role-specific modules (e.g., “When to contact the DPO”) for PhDs.  
+* Use real examples to make legal concepts relatable and illustrate practical consequences.  
+* Incorporate legal or ethics officers into the training to strengthen collaboration.  
+* Evaluate training outcomes annually and make adjustments based on participant feedback and policy updates.
+
+**✔ Keep communication visible and ongoing**  
+When reviewing or creating data management plans (DMPs), remind researchers to map legal aspects of data acquisition, storage and sharing early in the process.
+
+* Promote legal contacts in onboarding materials and welcome emails.  
+* Feature a “Legal Quick Links” box on the institutional RDM webpage with essential contacts, FAQs and tools.  
+* Include legal referral prompts in RDM presentations and onboarding slides.  
+* Update and promote new resources or procedural changes via newsletters and intranet announcements.  
+* Clarify expected timelines so researchers don’t fear delays (e.g., “Legal reviews usually take 10 days”).  
+* Maintain a version history of updates to ensure traceability and continuous improvement.
+
+**5. Review and strengthen legal processes regularly**
+
+✔ **Monitor effectiveness and adapt**
+
+Regularly review how legal support works across the institution to ensure it remains aligned with evolving laws, policies and researcher needs.
+
+* Collect feedback from researchers, data stewards and legal support staff on the usability and clarity of the available legal resources.  
+* Analyse which legal topics or questions arise most frequently and identify where additional training or guidance is needed.  
+* Review and update all procedures and materials at least annually, or sooner if major legislative or institutional changes occur.
+
+## Guidelines (from git)
 The following cheats might help you to get your own legal framework going or improve the already in place system. It is understandable, if you have a specific legal department, that you might not be able to change their systems; however, you can improve the knowledge of the researchers about already in-place procedures and how to approach specific people in the legal department regarding different topics.  
 
 ### Know your role and tasks as a Data Steward


### PR DESCRIPTION
Git already had a template it the text and approach is different from content of Gdoc. I personally prefer git version but not in position to decide. Both versions are presented on this page now and should be merged during contentathon. 