### PR TITLE
Add section intro to Guidance and Maturity model index pages

### DIFF
--- a/pages/guidance.md
+++ b/pages/guidance.md
@@ -1,7 +1,11 @@
 ---
 title: Guidance
-page_img: # none it doesnt't work
+description: Step-by-step advice for the things data stewards actually do – writing an RDM strategy, building support networks, communicating about RDM, and navigating legal and data-protection requirements.
+page_id: guidance-index
 ---
 
+<p class="section-eyebrow">SIGNPOSTS</p>
+
+<p class="drop-cap">Signposts are the handbook's <em>practical how-to</em>. Each page covers a specific area of data stewardship practice – from legal frameworks and data protection to training, support networks, and RDM communication. Most useful when you're starting something for the first time, or when you need a structured approach to a familiar problem.</p>
 
 {% include section-navigation-tiles.html type="Guidance" %}

--- a/pages/maturity-model.md
+++ b/pages/maturity-model.md
@@ -1,7 +1,13 @@
 ---
 title: Maturity model
-page_img: # none it doesnt't work
+description: A self-assessment framework for benchmarking your institution's data stewardship maturity across four domains – strategy, data management, legal and governance, and support.
+page_id: maturity-model-index
 ---
+
+<p class="section-eyebrow">WAYPOINTS</p>
+
+<p class="drop-cap">Waypoints are the handbook's <em>self-assessment framework</em>. The maturity model lets you benchmark your institution's data stewardship practice across four domains. Use it to see where you are, identify where to invest next, and make the case for resources or organisational change.</p>
+
 {% include auto-expand.html %}
 
 ## Indicators


### PR DESCRIPTION
The Guidance and Maturity model index pages were missing the eyebrow label and drop-cap intro paragraph that the Case studies index already has.

Adds SIGNPOSTS eyebrow + intro to guidance.md
Adds WAYPOINTS eyebrow + intro to maturity-model.md
Adds description and page_id frontmatter fields to both (matching the case-studies pattern)
Removes the broken page_img: # none it doesnt't work comment from both files